### PR TITLE
Point to data and metadata config forms

### DIFF
--- a/_data/site_config.yml
+++ b/_data/site_config.yml
@@ -58,7 +58,7 @@ create_pages:
 custom_css: []
 custom_js:
   - /assets/js/custom.js
-data_edit_url: ''
+data_edit_url: data
 data_fields:
   units: ''
   series: ''
@@ -201,7 +201,7 @@ menu:
   - path: /news
     translation_key: menu.updates
     dropdown: []
-metadata_edit_url: ''
+metadata_edit_url: metadata
 metadata_tabs: []
 news:
   category_links: false


### PR DESCRIPTION
Since data and metadata forms are enabled out of the box, these "urls" should be set as well.